### PR TITLE
fix(text-indents): Apply indent to only the first line

### DIFF
--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -113,14 +113,19 @@ const layoutParagraph = (engines, options) => (rect, paragraph) => {
     lineHeight,
   );
 
-  const widths = offsetsAndWidths.map((item, index) => {
+  // duplicating the last line width to avoid applying identations to all the lines
+  const extendedOffsetsAndWidths = [
+    ...offsetsAndWidths,
+    offsetsAndWidths[offsetsAndWidths.length - 1],
+  ];
+  const widths = extendedOffsetsAndWidths.map((item, index) => {
     if (index === 0) {
       return item.width - indent;
     }
     return item.width;
   });
 
-  const offsets = offsetsAndWidths.map((item, index) => {
+  const offsets = extendedOffsetsAndWidths.map((item, index) => {
     if (index === 0) {
       return item.offset + indent;
     }


### PR DESCRIPTION
Prevents adding indents to all the lines in a paragraph.