### PR TITLE
fix(text-overflow): re-layoutText in yogakit measureText

### DIFF
--- a/packages/layout/src/steps/resolveDimensions.js
+++ b/packages/layout/src/steps/resolveDimensions.js
@@ -238,7 +238,7 @@ const createYogaNodes = (
         });
 
         if (fillNeeded) {
-          console.log('Fill needed', fillNeeded);
+          // console.log('Fill needed', fillNeeded);
           yogaNode.setMeasureFunc(measureSpaceFillingView(fillNeeded));
           yogaNode.markDirty();
           rootNode.calculateLayout();
@@ -349,7 +349,6 @@ export const resolvePageDimensions = (page, fontStore) =>
     R.isNil,
     R.always(null),
     R.compose(
-      R.tap(() => console.warn('Destroyed nodes')),
       destroyYogaNodes,
       freeYogaNodes,
       persistDimensions,

--- a/packages/layout/src/text/measureText.js
+++ b/packages/layout/src/text/measureText.js
@@ -31,8 +31,10 @@ const measureText = (
   height,
 ) => {
   if (widthMode === Yoga.MEASURE_MODE_EXACTLY) {
-    if (!node.lines || maskRects.length) {
+    const assumedDimensions = `${width||0}:${height||0}`;
+    if (!node.lines || maskRects.length || node.assumedDimensions !== assumedDimensions) {
       node.lines = layoutText(node, maskRects, width, height, fontStore);
+      node.assumedDimensions = assumedDimensions;
     }
     return { height: linesHeight(node) };
   }


### PR DESCRIPTION
YogaKit calls the text measurement function multiple times while
layouting, with different widths (during the process of flexbox calculation).
React-pdf should therefore recalculate the text layout at each of these
calls in order to prevent overflows.