### PR TITLE
Revert "fix(text-overflow): re-layoutText in yogakit measureText"

### DIFF
--- a/packages/layout/src/text/measureText.js
+++ b/packages/layout/src/text/measureText.js
@@ -31,10 +31,8 @@ const measureText = (
   height,
 ) => {
   if (widthMode === Yoga.MEASURE_MODE_EXACTLY) {
-    const assumedDimensions = `${width||0}:${height||0}`;
-    if (!node.lines || maskRects.length || node.assumedDimensions !== assumedDimensions) {
+    if (!node.lines || maskRects.length) {
       node.lines = layoutText(node, maskRects, width, height, fontStore);
-      node.assumedDimensions = assumedDimensions;
     }
     return { height: linesHeight(node) };
   }


### PR DESCRIPTION
This reverts commit 83a70777c58138f3f439fae3042042ed0cc02b4a.