### PR TITLE
fix(justification-engine): return valid value

### DIFF
--- a/packages/textkit/src/engines/justification/index.js
+++ b/packages/textkit/src/engines/justification/index.js
@@ -40,7 +40,7 @@ const justifyLine = (distances, line) => {
 const justification = (options, line) => {
   const gap = line.box.width - advanceWidth(line);
 
-  if (gap === 0) return; // Exact fit
+  if (gap === 0) return line; // Exact fit
 
   const factors = getFactors(gap, line, options);
   const distances = getDistances(gap, factors);


### PR DESCRIPTION
When a particular line does not need any special justification, it should return the original value (line).

Otherwise, the rendering engine breaks because the output of the justification engine is passed forward in the pipeline.