### PR TITLE
Fix/hyphens: Fix nodes generation logic for line breaker

### DIFF
--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -5,6 +5,7 @@ import linebreak from './linebreak';
 import slice from '../../attributedString/slice';
 import insertGlyph from '../../attributedString/insertGlyph';
 import advanceWidthBetween from '../../attributedString/advanceWidthBetween';
+import hasOnlySpaces from '../../utils/hasOnlySpaces';
 
 const HYPHEN = 0x002d;
 const TOLERANCE_STEPS = 5;
@@ -86,7 +87,7 @@ const getNodes = (attributedString, { align }, options) => {
 
       acc.push(linebreak.glue(width, value, stretch, shrink));
     } else {
-      const hyphenated = syllables[index + 1] !== ' ';
+      const hyphenated = !hasOnlySpaces(syllables[index + 1]);
 
       const value = { start, end: start + s.length };
       acc.push(linebreak.box(width, value, hyphenated));

--- a/packages/textkit/src/utils/hasOnlySpaces.js
+++ b/packages/textkit/src/utils/hasOnlySpaces.js
@@ -1,0 +1,13 @@
+/**
+ * Check string only has spaces
+ * 
+ * @param {String} value string value
+ * @returns {Boolean} value has spaces
+ */
+const hasOnlySpaces = value => {
+  if(!value) return false;
+  const regx = /^[\s]+$/;
+  return regx.test(value);
+};
+
+export default hasOnlySpaces;


### PR DESCRIPTION
- Hyphens are added according to the `penalty nodes`
- Previously `penalty nodes` are added based on a single space character. But there may be multiple space characters.
- `hasOnlySpaces` util function has been added to check whether the string has only space characters (only single or multiple).