### PR TITLE
Fix/line breaking

### DIFF
--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -27,12 +27,14 @@ const opts = {
 const getUrlRegions = attributedString => {
   const urlRegions = [];
 
-  for (let index = 0; index < attributedString.runs.length; index += 1) {
-    const { start, end } = attributedString.runs[index];
-    const strPart = attributedString.string.slice(start, end);
-    if (isUrl(strPart)) {
-      urlRegions.push({ start, end });
+  const words = attributedString.string.split(/([ ]+)/g).filter(Boolean);
+  let start = 0;
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index];
+    if (isUrl(word)) {
+      urlRegions.push({ start, end: start + word.length });
     }
+    start += word.length;
   }
 
   return urlRegions;
@@ -42,22 +44,22 @@ const getUrlRegions = attributedString => {
  * Check whether the line is in the URL region
  *
  * @param {Object[]} urlRegions URL Regions
- * @param {Number} attributedStringLineStartPosition attributed string line start position
+ * @param {Number} attributedStringLineEndPosition attributed string line end position
  * @returns {Boolean} if the line is in the URL region return true otherwise false
  */
-const isInUrlRegion = (urlRegions, attributedStringLineStartPosition) => {
+const isInUrlRegion = (urlRegions, attributedStringLineEndPosition) => {
   // last url region end position before the start of the line region
   let lastUrlRegionEnd = null;
   for (let index = 0; index < urlRegions.length; index += 1) {
     const { start, end } = urlRegions[index];
-    if (start <= attributedStringLineStartPosition) {
+    if (start <= attributedStringLineEndPosition) {
       lastUrlRegionEnd = end;
     }
   }
 
   if (!lastUrlRegionEnd) return false;
 
-  return attributedStringLineStartPosition < lastUrlRegionEnd;
+  return attributedStringLineEndPosition < lastUrlRegionEnd;
 };
 
 /**
@@ -87,7 +89,7 @@ const breakLines = (string, nodes, breaks) => {
 
       line = slice(start, end, string);
       // If the line is a part of a URL Hyphen character will not be inserted (Inserting a hyphen will change the URL)
-      if (!isInUrlRegion(urlRegions, start)) {
+      if (!isInUrlRegion(urlRegions, end)) {
         line = insertGlyph(line.length, HYPHEN, line);
       }
     } else {

--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -6,6 +6,7 @@ import slice from '../../attributedString/slice';
 import insertGlyph from '../../attributedString/insertGlyph';
 import advanceWidthBetween from '../../attributedString/advanceWidthBetween';
 import hasOnlySpaces from '../../utils/hasOnlySpaces';
+import isUrl from '../../utils/isUrl';
 
 const HYPHEN = 0x002d;
 const TOLERANCE_STEPS = 5;
@@ -15,6 +16,48 @@ const opts = {
   width: 3,
   stretch: 6,
   shrink: 9,
+};
+
+/**
+ * Get regions of urls in the attributed string
+ *
+ * @param {Object} attributedString attributed string
+ * @returns {Array} regions of urls
+ */
+const getUrlRegions = attributedString => {
+  const urlRegions = [];
+
+  for (let index = 0; index < attributedString.runs.length; index += 1) {
+    const { start, end } = attributedString.runs[index];
+    const strPart = attributedString.string.slice(start, end);
+    if (isUrl(strPart)) {
+      urlRegions.push({ start, end });
+    }
+  }
+
+  return urlRegions;
+};
+
+/**
+ * Check whether the line is in the URL region
+ *
+ * @param {Object[]} urlRegions URL Regions
+ * @param {Number} attributedStringLineStartPosition attributed string line start position
+ * @returns {Boolean} if the line is in the URL region return true otherwise false
+ */
+const isInUrlRegion = (urlRegions, attributedStringLineStartPosition) => {
+  // last url region end position before the start of the line region
+  let lastUrlRegionEnd = null;
+  for (let index = 0; index < urlRegions.length; index += 1) {
+    const { start, end } = urlRegions[index];
+    if (start <= attributedStringLineStartPosition) {
+      lastUrlRegionEnd = end;
+    }
+  }
+
+  if (!lastUrlRegionEnd) return false;
+
+  return attributedStringLineStartPosition < lastUrlRegionEnd;
 };
 
 /**
@@ -29,6 +72,8 @@ const breakLines = (string, nodes, breaks) => {
   let start = 0;
   let end = null;
 
+  const urlRegions = getUrlRegions(string);
+
   const lines = breaks.reduce((acc, breakPoint) => {
     const node = nodes[breakPoint.position];
     const prevNode = nodes[breakPoint.position - 1];
@@ -41,8 +86,8 @@ const breakLines = (string, nodes, breaks) => {
       end = prevNode.value.end;
 
       line = slice(start, end, string);
-      // If the line is a URL Hyphen character will not be inserted (Inserting a hyphen will change the URL)
-      if (!line.isUrl) {
+      // If the line is a part of a URL Hyphen character will not be inserted (Inserting a hyphen will change the URL)
+      if (!isInUrlRegion(urlRegions, start)) {
         line = insertGlyph(line.length, HYPHEN, line);
       }
     } else {

--- a/packages/textkit/src/layout/wrapWords.js
+++ b/packages/textkit/src/layout/wrapWords.js
@@ -17,9 +17,9 @@ const defaultHyphenationEngine = word => [word];
  * This wrapper function handles the special case of word being a URL
  * URL text length is often longer than the page width. For that URL text will be split into charactors
  * Ex: http://example.com?text=xxx -> ["h","t","t","p",":","/","/","e","x","a","m","p","l","e",".","c","o","m","?","t","e","x","t","=","x","x","x"]
- * 
+ *
  * @param {HyphenationEngine} hyphenator
- * @param {String} word 
+ * @param {String} word
  * @returns {HyphenationEngine}
  */
 const hyphenateWordWrapper = (hyphenator, word) => {
@@ -46,8 +46,6 @@ const wrapWords = (engines = {}, options = {}, attributedString) => {
     (engines.wordHyphenation && engines.wordHyphenation(options)) ||
     defaultHyphenationEngine;
 
-  const _isUrl = isUrl(attributedString.string);
-
   for (let i = 0; i < attributedString.runs.length; i += 1) {
     let string = '';
     const run = attributedString.runs[i];
@@ -66,9 +64,7 @@ const wrapWords = (engines = {}, options = {}, attributedString) => {
     fragments.push({ string, attributes: run.attributes });
   }
 
-  // Pass isUrl flag to show this string in the attributedString is a URL
-  // This flag is used in the line breaker engine to determine whether or not to insert a hyphen into the URL
-  return { ...fromFragments(fragments), syllables, isUrl: _isUrl };
+  return { ...fromFragments(fragments), syllables };
 };
 
 export default R.curryN(3, wrapWords);


### PR DESCRIPTION
- Remove the `isURL` flag in the attributed string
- Update `breakLines` process for URLs
   With this update, Hyphens will not be added inside the URL when line breaking