### PR TITLE
Allow specifying universal fallback fonts

### DIFF
--- a/packages/font/src/index.js
+++ b/packages/font/src/index.js
@@ -82,6 +82,28 @@ function FontStore() {
   this.getHyphenationCallback = () => hyphenationCallback;
 
   this.getRegisteredFontFamilies = () => Object.keys(fonts);
+
+  this.setFallbackFontFamilies = fontFamilies => {
+    if(!Array.isArray(fontFamilies)){
+      throw new Error('Fallback font families must be an array of strings');
+    }
+
+    for(let i=0; i< fontFamilies.length; i+= 1) {
+      const fontFamily = fontFamilies[i];
+      const isStandard = standard.includes(fontFamily);
+      const isRegistered = fonts[fontFamily];
+
+      if(!isStandard && !isRegistered){
+        throw new Error(
+          `Fallback font family not registered: ${fontFamily}. Please register it calling Font.register() method.`,
+        );
+      }
+    }
+
+    this.fallbackFontFamilies = fontFamilies;
+  };
+
+  this.getFallbackFontFamilies = () => this.fallbackFontFamilies || [];
 }
 
 export default FontStore;

--- a/packages/layout/src/steps/resolveAssets.js
+++ b/packages/layout/src/steps/resolveAssets.js
@@ -43,6 +43,11 @@ const fetchAssets = (fontStore, node) => {
     }
   }
 
+  // fetch the fallback font families
+  fontStore.getFallbackFontFamilies().forEach((fontFamily) => {
+    promises.push(fontStore.load({ fontFamily }));
+  });
+
   return promises;
 };
 

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -40,7 +40,7 @@ const determineFont = (codePoint, defaultFont, fallbackFonts) => {
     throw new Error('Default font is null')
   }
 
-  return possibleFonts[0];
+  return possibleFonts[0] || getDefaultFallbackFont();
 }
 
 const fontSubstitution = () => ({ string, runs }) => {

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -17,13 +17,27 @@ const getOrCreateFont = name => {
   return font;
 };
 
-const getFallbackFont = () => getOrCreateFont('Helvetica');
+const getDefaultFallbackFont = () => getOrCreateFont('Helvetica');
 
-const shouldFallbackToFont = (codePoint, font) =>
-  !font ||
-  (!IGNORED_CODE_POINTS.includes(codePoint) &&
-    !font.hasGlyphForCodePoint(codePoint) &&
-    getFallbackFont().hasGlyphForCodePoint(codePoint));
+const isGlyphAvailable = (codePoint, font) => font.hasGlyphForCodePoint(codePoint);
+
+/**
+ * Determines the font that can render a specific character
+ * 
+ * Priority Order: (desired font family) > (first feasible of the specified fallback font families) > Helvetica
+ * @returns Font
+ */
+const determineFont = (codePoint, defaultFont, fallbackFonts) => {
+  const possibleFonts = [...fallbackFonts];
+  if(defaultFont) possibleFonts.unshift(defaultFont);
+
+  for(let i=0; i<possibleFonts.length; i+= 1) {
+    if(IGNORED_CODE_POINTS.includes(codePoint)) return possibleFonts[i];
+    if(isGlyphAvailable(codePoint, possibleFonts[i])) return possibleFonts[i];
+  }
+
+  return getDefaultFallbackFont();
+}
 
 const fontSubstitution = () => ({ string, runs }) => {
   let lastFont = null;
@@ -41,6 +55,8 @@ const fontSubstitution = () => ({ string, runs }) => {
         ? getOrCreateFont(run.attributes.font)
         : run.attributes.font;
 
+    const fallbackFonts = [...(run.attributes.fallbackFonts || []).map((font) => typeof font === 'string' ? getOrCreateFont(font) : font), getDefaultFallbackFont()];
+
     if (string.length === 0) {
       res.push({ start: 0, end: 0, attributes: { font: defaultFont } });
       break;
@@ -51,9 +67,9 @@ const fontSubstitution = () => ({ string, runs }) => {
     for (let j = 0; j < chars.length; j += 1) {
       const char = chars[j];
       const codePoint = char.codePointAt();
-      const shouldFallback = shouldFallbackToFont(codePoint, defaultFont);
-      // If the default font does not have a glyph and the fallback font does, we use it
-      const font = shouldFallback ? getFallbackFont() : defaultFont;
+
+      // Determine which font can be used to render a character into the PDF
+      const font = determineFont(codePoint, defaultFont, fallbackFonts);
       const fontSize = getFontSize(run);
 
       // If anything that would impact res has changed, update it

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -36,7 +36,11 @@ const determineFont = (codePoint, defaultFont, fallbackFonts) => {
     if(isGlyphAvailable(codePoint, possibleFonts[i])) return possibleFonts[i];
   }
 
-  return getDefaultFallbackFont();
+  if(!possibleFonts[0]){
+    throw new Error('Default font is null')
+  }
+
+  return possibleFonts[0];
 }
 
 const fontSubstitution = () => ({ string, runs }) => {

--- a/packages/layout/src/text/getAttributedString.js
+++ b/packages/layout/src/text/getAttributedString.js
@@ -44,15 +44,27 @@ const getFragments = (fontStore, instance, parentLink, level = 0) => {
     fontVariant = 'normal',
   } = instance.style;
 
-  const opts = { fontFamily, fontWeight, fontStyle };
-  const obj = fontStore ? fontStore.getFont(opts) : null;
-  const font = obj ? obj.data : fontFamily;
+  const fontFamilies = [fontFamily, ...fontStore.getFallbackFontFamilies()];
+
+  let font;
+  const fonts = [];
+  
+  for(let i=0; i<fontFamilies.length; i+=1) {
+    const opts = { fontFamily: fontFamilies[i], fontWeight, fontStyle };
+    const obj = fontStore ? fontStore.getFont(opts) : null;
+    font = obj ? obj.data : fontFamilies[i];
+    fonts.push(font);
+  }
+  
+  [font] = fonts;
+  const fallbackFonts = fonts.slice(1);
 
   // Don't pass main background color to textkit. Will be rendered by the render package instead
   const backgroundColor = level === 0 ? null : instance.style.backgroundColor;
 
   const attributes = {
     font,
+    fallbackFonts,
     color,
     opacity,
     fontSize,

--- a/packages/textkit/src/layout/applyDefaultStyles.js
+++ b/packages/textkit/src/layout/applyDefaultStyles.js
@@ -20,6 +20,7 @@ const applyRunStyles = R.evolve({
     features: a.features || [],
     fill: a.fill !== false,
     font: a.font || null,
+    fallbackFonts: a.fallbackFonts || [],
     fontSize: a.fontSize || 12,
     hangingPunctuation: a.hangingPunctuation || false,
     hyphenationFactor: a.hyphenationFactor || 0,

--- a/packages/types/font.d.ts
+++ b/packages/types/font.d.ts
@@ -81,4 +81,6 @@ export interface FontStore {
   registerEmojiSource: (emojiSource: EmojiSource) => void;
   getFont: (descriptor: FontDescriptor) => RegisteredFont | undefined;
   registerHyphenationCallback: (callback: HyphenationCallback) => void;
+  setFallbackFontFamilies: (fontFamilies: string[]) => void;
+  getFallbackFontFamilies: () => string[];
 }


### PR DESCRIPTION
This feature allows to set an array of fallback fonts to try and use in case a certain glyph is not available in the default font.

Fallback font families can be registered with Font.setFallbackFontFamilies(['Arial-Unicode-MS']); syntax.