### PR TITLE
fix(run-index): return -1 when no matching result

### DIFF
--- a/packages/textkit/src/run/runIndexAt.js
+++ b/packages/textkit/src/run/runIndexAt.js
@@ -16,6 +16,9 @@ const runIndexAt = (x, runs) => {
   for (let b = n; b >= 1; b = Math.floor(b / 2)) {
     while (!ok(k + b)) k += b;
   }
+  // no results found
+  if(k+1 === runs.length) return -1;
+
   return k + 1;
 };
 


### PR DESCRIPTION
-1 has to be returned when there's no match.