### PR TITLE
fix(footnotes): Fix nested array issue

### DIFF
--- a/packages/layout/src/footnotes/mapFootnotesToView.js
+++ b/packages/layout/src/footnotes/mapFootnotesToView.js
@@ -46,10 +46,11 @@ function mapFootnotesToView(footnotes, width) {
       style: {
         paddingTop: 10,
       },
-      children: [processed],
+      children: [],
     },
   });
 
+  it.children = processed;
   return it;
 }
 


### PR DESCRIPTION
## Context
using 
```js
children: [processed],
```
appends the `processed` array as a nested element and this causes render issues later in the pipeline

## Fix
although the correct fix for this should be;
```js
children: [...processed],
```
this generates a weird output causing footnote view to take more space than it needed

so, going with this fix for now 