### PR TITLE
fix(pageBalancing): prevent re-layouting a split portion of a paragraph

### DIFF
--- a/packages/layout/src/steps/resolvePageBalancing.js
+++ b/packages/layout/src/steps/resolvePageBalancing.js
@@ -87,6 +87,12 @@ const applyLetterSpacingProp = (node, letterSpacing) => {
 };
 
 const dropLayoutAttributes = node => {
+  // avoid dropping the layout attributes if the node is an artefact. The text content has been split into
+  // 2 pages, so we don't want to re-layout the paragraph
+  if (isOrphanWidowProtectionArtefact(node)) {
+    return node;
+  }
+
   if (isText(node)) {
     return R.compose(
       R.assocPath(['box'], {}),


### PR DESCRIPTION
Resolves #AT-845

Before:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/30839188/209822147-abeeb882-784d-4e58-b517-f3ade6b789e2.png">

After:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/30839188/209822174-6fb4e1e0-d233-4b80-b858-db0442db248f.png">
