### PR TITLE
fix/AT-2118 fix footnote duplication with soft breaks and keep settings 

### DIFF
--- a/packages/layout/src/footnotes/getFootnotes.js
+++ b/packages/layout/src/footnotes/getFootnotes.js
@@ -76,15 +76,18 @@ function getFootnotes(node, top = 0) {
     );
     const notes = [];
     let topUpto = nodeTop + parentTop;
+    let previousLines = 0;
 
     for (let i = 0; i < node.lines.length; i += 1) {
       const line = node.lines[i];
+      if (i - 1 >= 0) previousLines += node.lines[i - 1].string.length + 1;
       notes.push(
         ...calculatedNotes
-          .filter(
-            e => e.loc - e.ref.length < line.textBefore + line.string.length,
-          )
-          .filter(e => e.loc >= line.textBefore)
+          .filter(  // check if the footnote is present within a line
+            e =>
+              e.loc - e.ref.length < line.string.length + previousLines &&
+              e.loc - e.ref.length >= previousLines,
+          ) 
           .map(r => ({
             ...r,
             approxTop: topUpto,

--- a/packages/layout/src/node/splitNodes.js
+++ b/packages/layout/src/node/splitNodes.js
@@ -75,7 +75,8 @@ const splitNodes = (height, contentArea, nodes) => {
         }),
       })(child);
 
-      currentChildren.push(...futureFixedNodes);
+      //removed pushing futureFixedNodes into currentChildren to prevent footnote duplication with keep settings
+      //currentChildren.push(...futureFixedNodes);
       nextChildren.push(next, ...futureNodes);
       break;
     }


### PR DESCRIPTION
In order to fix the footnote duplication with keep settings part of the remaining code had to be removed. therefore this fix has a chance to affect certain areas of the print especially with breaks. 