### PR TITLE
fix: return original page if no candidate value found in resolvePageBalancing

### DIFF
--- a/packages/layout/src/steps/resolvePageBalancing.js
+++ b/packages/layout/src/steps/resolvePageBalancing.js
@@ -170,6 +170,11 @@ const relayoutPageToIncreaseLines = async (pageIndex, doc, fontStore) => {
     }
   }
 
+  // Return the original page if no candidate value was found
+  if (!memoizedResults.has(relativeLetterSpace)) {
+    return page;
+  }
+
   return memoizedResults.get(relativeLetterSpace)[1];
 };
 


### PR DESCRIPTION
### Fix: Best of both error in PDF generation

#### Issue:
PDF generation crashed with TypeError when no valid letter-spacing candidate was found, causing infinite loading in the UI.

#### Solution:
Added a fallback to return the original page when no candidate value is available.

#### Impact:
Prevents runtime error and ensures PDF generation completes successfully.